### PR TITLE
Update to EF values of NBC reference DHW Systems

### DIFF
--- a/HTAP-options.json
+++ b/HTAP-options.json
@@ -10189,7 +10189,7 @@
             "Opt-H2K-Fuel": "2",
             "Opt-H2K-TankType": "2",
             "Opt-H2K-TankSize": "189.3",
-            "Opt-H2K-EF": "0.67",
+            "Opt-H2K-EF": "0.575",
             "Opt-H2K-IntHeatPumpCOP": "NA",
             "Opt-H2K-FlueDiameter": "76.2"
           }
@@ -10206,7 +10206,7 @@
             "Opt-H2K-Fuel": "1",
             "Opt-H2K-TankType": "3",
             "Opt-H2K-TankSize": "189.3",
-            "Opt-H2K-EF": "0.894",
+            "Opt-H2K-EF": "0.876",
             "Opt-H2K-IntHeatPumpCOP": "NA",
             "Opt-H2K-FlueDiameter": "0"
           }
@@ -10223,7 +10223,7 @@
             "Opt-H2K-Fuel": "3",
             "Opt-H2K-TankType": "2",
             "Opt-H2K-TankSize": "189.3",
-            "Opt-H2K-EF": "0.59",
+            "Opt-H2K-EF": "0.495",
             "Opt-H2K-IntHeatPumpCOP": "NA",
             "Opt-H2K-FlueDiameter": "0"
           }


### PR DESCRIPTION
The EF values of the NBC DHW systems have been updated to reflect requirements in Table 9.36.4.2
All reference DHW are conventional tanks systems with volume V=189.3 L

Per the table for gas-fired systems: EF = 0.67-0.0005V = 0.575
for oil-fired: EF = 0.59-0.0005V = 0.495

For reference electric tank systems a top-inlet was assumed, and therefore a maximum standby loss
of 35+0.20V = 72.9 W per Table 9.36.4.2. Assuming input capacity of 3 kW, and using the EF equation
in the OEE NBC 9.36.5 HOT2000 modelling guide, the EF was adjusted to 0.876