### PR TITLE
Git version stamping

### DIFF
--- a/htap-prm.rb
+++ b/htap-prm.rb
@@ -1266,11 +1266,6 @@ end
 # Dump help text, if no argument given
 
 
-
-
-$gMasterPath = Dir.getwd()
-
-
 $cmdlineopts = Hash.new
 $gTest_params = Hash.new        # test parameters
 $gTest_params["verbosity"] = "Lquiet"

--- a/htap-prm.rb
+++ b/htap-prm.rb
@@ -621,6 +621,11 @@ def run_these_cases(current_task_files)
 
   fJSONout  = File.open("#{$gOutputJSON}", 'w')
   firstJSONLine = true
+  branch_name, revision_number = HTAPData.getGitInfo()
+  # DEBUGGING (TODO: REMOVE)
+  # pp branch_name
+  # pp revision_number
+  # exit
   while  ! $RunsDone
 
       $batchCount = $batchCount + 1

--- a/include/HTAPUtils.rb
+++ b/include/HTAPUtils.rb
@@ -20,6 +20,18 @@ def HTAPInit()
 
   log_out ("Parsing configuration file")
   HTAPConfig.parseConfigData()
+
+  # Get version information
+  $branch_name, $revision_number = HTAPData.getGitInfo()
+  log_out ("#{$program} source: Branch #{$branch_name}, revision #{$revision_number}\n")
+
+  # Debug git info
+  debug_out ("Git versioning: Branch      #{$branch_name}\n")
+  debug_out ("Git versioning: Revision \# #{$revision_number}\n")
+
+
+
+
 end
 
 module HTAPData
@@ -749,8 +761,8 @@ module HTAPData
 
   def HTAPData.getGitInfo()
     revision_number=`git log --pretty=format:'%h' -n 1`
-	revision_number.gsub!(/^'/, '')
-	revision_number.gsub!(/'$/, '')
+	  revision_number.gsub!(/^'/, '')
+	  revision_number.gsub!(/'$/, '')
     branch_name=`git rev-parse --abbrev-ref HEAD`
 	return branch_name.strip, revision_number.strip
   end

--- a/include/HTAPUtils.rb
+++ b/include/HTAPUtils.rb
@@ -2,6 +2,9 @@
 
 def HTAPInit()
   $startProcessTime = Time.now
+
+  $gMasterPath = Dir.getwd()
+
   progShort = $program
   progShort.gsub!(/\.rb/,"")
   debug_out "Opening log files for #{progShort}"
@@ -16,12 +19,14 @@ def HTAPInit()
   $allok = true
 
   $scriptLocation = File.expand_path(File.dirname(__FILE__)+"\\..\\.")
+
   log_out ("#{$program} location: #{$scriptLocation}\n")
 
-  log_out ("Parsing configuration file")
+  log_out ("Parsing configuration file\n")
   HTAPConfig.parseConfigData()
 
   # Get version information
+  log_out ("Recovering git version info\n")
   $branch_name, $revision_number = HTAPData.getGitInfo()
   log_out ("#{$program} source: Branch #{$branch_name}, revision #{$revision_number}\n")
 
@@ -759,12 +764,24 @@ module HTAPData
 
   end
 
+  # Recovers version info from git, returns 'unknown' if errors are encountered
   def HTAPData.getGitInfo()
-    revision_number=`git log --pretty=format:'%h' -n 1`
-	  revision_number.gsub!(/^'/, '')
-	  revision_number.gsub!(/'$/, '')
-    branch_name=`git rev-parse --abbrev-ref HEAD`
-	return branch_name.strip, revision_number.strip
+
+    begin
+      # Change to directory where scripts are located.
+      Dir.chdir($scriptLocation)
+      revision_number=`git log --pretty=format:'%h' -n 1`
+	    revision_number.gsub!(/^'/, '')
+	    revision_number.gsub!(/'$/, '')
+      branch_name=`git rev-parse --abbrev-ref HEAD`
+    rescue
+      revision_number = "unknown"
+      branch_name = "unknown"
+    ensure
+      Dir.chdir($gMasterPath)
+    end
+
+  	return branch_name.strip, revision_number.strip
   end
 
   def self.formatSqFtSqM(area)

--- a/include/HTAPUtils.rb
+++ b/include/HTAPUtils.rb
@@ -747,6 +747,14 @@ module HTAPData
 
   end
 
+  def HTAPData.getGitInfo()
+    revision_number=`git log --pretty=format:'%h' -n 1`
+	revision_number.gsub!(/^'/, '')
+	revision_number.gsub!(/'$/, '')
+    branch_name=`git rev-parse --abbrev-ref HEAD`
+	return branch_name.strip, revision_number.strip
+  end
+
   def self.formatSqFtSqM(area)
     return "--".rjust($numPad) if numOrDash(area) == "--"
     return ("#{(area*SF_PER_SM).round(0).to_s.rjust($numPad)} ft^2 (#{(area).round(0)} m^2)")

--- a/include/constants.rb
+++ b/include/constants.rb
@@ -244,4 +244,7 @@ CostingAuditReportName = 'HTAP-costing-audit-report.txt'
 ConfigDataFile = "htap.config"
 $gConfigData = Hash.new
 $newLine = true
-$logBufferCount = 0 
+$logBufferCount = 0
+
+$branch_name = ""
+$revision_number = ""

--- a/include/constants.rb
+++ b/include/constants.rb
@@ -248,3 +248,5 @@ $logBufferCount = 0
 
 $branch_name = ""
 $revision_number = ""
+
+$gMasterPath = ""

--- a/include/msgs.rb
+++ b/include/msgs.rb
@@ -80,6 +80,15 @@ def shortenToTerm(msg,extrashort = 0, truncStr="[...]")
   return shortmsg
 
 end
+
+def reportSRC(branch, revision)
+  stream_out ("\n")
+  # Maybe find link to remote reporsitory too?
+  stream_out (" GitHub source: \n")
+  stream_out ("    - Branch:   #{branch} \n")
+  stream_out ("    - Revision: #{revision} \n")
+  return
+end
 # =========================================================================================
 # Optionally write text to buffer -----------------------------------
 # =========================================================================================

--- a/substitute-h2k.rb
+++ b/substitute-h2k.rb
@@ -5345,6 +5345,18 @@ def ChangeWinCodeByOrient( winOrient, newValue, h2kCodeLibElements, h2kFileEleme
         $HCGeneralFound = false
         $HCSOCFound = false
 
+        # Get version information
+        $gResults["version"] = Hash.new
+        $gResults["version"]["h2kHouseFile"] = "#{h2kPostElements["HouseFile/Version"].attributes["major"]}.#{h2kPostElements["HouseFile/Version"].attributes["minor"]}"
+
+        $gResults["version"]["HOT2000"] = "v#{h2kPostElements["HouseFile/Application/Version"].attributes["major"]}"+
+                                          ".#{h2kPostElements["HouseFile/Application/Version"].attributes["minor"]}"+
+                                          "b#{h2kPostElements["HouseFile/Application/Version"].attributes["build"]}"
+
+
+
+
+
         # Make sure that the code we want is available
         h2kPostElements["HouseFile/AllResults"].elements.each do |element|
 
@@ -7330,10 +7342,13 @@ def ChangeWinCodeByOrient( winOrient, newValue, h2kCodeLibElements, h2kFileEleme
             if ( json_output ) then
 
               results = Hash.new
-              results[$aliasLongConfig] = { "OptionsFile"         =>  "#{$gOptionFile}",
-              "Recovered-results"   =>  "#{$outputHCode}"
-            }
-            results[$aliasLongArch] = {   "h2k-File"            =>  "#{$h2kFileName}",
+              results[$aliasLongConfig] = {
+                "OptionsFile"         =>  "#{$gOptionFile}",
+                "Recovered-results"   =>  "#{$outputHCode}",
+                "version" => $gResults["version"]
+              }
+
+              results[$aliasLongArch] = {   "h2k-File"            =>  "#{$h2kFileName}",
             "House-Builder"       =>  "#{$BuilderName}",
             "House-Type"          =>  "#{$HouseType}",
             "House-Storeys"       =>  "#{$HouseStoreys}",

--- a/substitute-h2k.rb
+++ b/substitute-h2k.rb
@@ -174,7 +174,8 @@ $aliasArch    = $aliasLongArch
 
 
 # Path where this script was started and considered master
-$gMasterPath = Dir.getwd()
+
+# Not sure why, but substiture-h2k.rb fails without this converison.
 $gMasterPath.gsub!(/\//, '\\')
 $unitCostFileName = "C:/HTAP/HTAPUnitCosts.json"
 


### PR DESCRIPTION
These changes allow HTAP to parse, report version information from Git, HOT2000 results files. They will aid future efforts to track and compare differerences between HTAP / HOT2000 versions. 

**NOTE THAT THEY CHANGE THE STRUCTURE OF THE JSON OUTPUT**
Key changes: 
- HTAP output is now nested inside a hash, called `htap-results`
- A new, top-level hash, `htap-configuration`, now contains information about versioning

Example JSON output below. 

```
{
  "htap-configuration": {
    "git-branch": "git_version_stamping",
    "git-revision": "6bf4cc0",
    "runs-by-h2kVersion": {
      "v11.6b10": 1
    }
  },
  "htap-results": [
    {
      "result-number": 1,
      "status": {...},
      "archetype": {...},
      "input": {...},
      "output": {...},
      "configuration": {
        "RunNumber": "1",
        "RunDirectory": "HTAP-work-0",
        "SaveDirectory": "HTAP-sim-1",
        "ChoiceFile": "sim-1.choices",
        "OptionsFile": "HTAP-options.json",
        "Recovered-results": "General",
        "version": {
          "h2kHouseFile": "1.3",
          "HOT2000": "v11.6b10"
        }
      },
      "cost-estimates": {...},
      "analysis:BCStepCode": {...}
    }
  ]
}
```