### PR TITLE
Quick fixes

### DIFF
--- a/htap-prm.rb
+++ b/htap-prm.rb
@@ -911,11 +911,19 @@ def run_these_cases(current_task_files)
           thisRunResults = Hash.new
           thisRunResults = JSON.parse(contents)
 
+          if ( ! $gTest_params["audit-costs"] ) then 
+            thisRunResults["costEstimates"]["audit"] = nil 
+          end 
+
 
           #$RunResults["run-#{thread3}"]["output"] = thisRunResults["output"]
           #$RunResults["run-#{thread3}"]["cost-estimates"] = thisRunResults["costEstimates"]
           #$RunResults["run-#{thread3}"]["input"] = thisRunResults["input"]
           #$RunResults["run-#{thread3}"]["archetype"] = thisRunResults["archetype"]
+
+
+          
+
 
           thisRunResults.keys.each do | section |
             if ( section.eql?("status") || section.eql?("configuration") ) then
@@ -1379,16 +1387,9 @@ optparse = OptionParser.new do |opts|
 
    end
 
-
-
    #opts.on("-w", "--warnings", "Report warning messages") do
    #   $gWarn = true
    #end
-
-
-
-
-
 
    #opts.on("-s", "--substitute-h2k-path FILE", "Specified path to substitute RB ") do |o|
    #   $cmdlineopts["substitute"] = o
@@ -1398,23 +1399,12 @@ optparse = OptionParser.new do |opts|
    #   end
    #end
 
-
-
    #opts.on("-ss", "--snailStart X", "Optional delay (X sec) between spawning threads on the ",
    #                                 "first batch (and ignored on subsequent batches). May improve",
    #                                 "stability on highly parallel machines with slow disk I/O." ) do |o|
    #   $snailStart = true
    #   $snailStartWait = o.to_f
    #end
-
-
-
-
-
-
-
-
-
 
    opts.separator ""
 
@@ -1428,14 +1418,13 @@ optparse = OptionParser.new do |opts|
 
 end
 
-stream_out(drawRuler("A simple parallel run manager for HTAP"))
-
-reportSRC($branch_name, $revision_number)
-
 if ARGV.empty? then
    ARGV.push "-h"
 end
 optparse.parse!    # Note: parse! strips all arguments from ARGV and parse does not
+
+stream_out(drawRuler("A simple parallel run manager for HTAP"))
+reportSRC($branch_name, $revision_number)
 
 
 $RunNumber = 0

--- a/htap-prm.rb
+++ b/htap-prm.rb
@@ -1076,6 +1076,11 @@ def run_these_cases(current_task_files)
           "configuration"          => $RunResults[run]["configuration"     ],
           "cost-estimates"         => $RunResults[run]["cost-estimates"]
         }
+   
+        if ( ! $gTest_params["audit-costs"] ) then 
+          thisRunHash["cost-estimates"]["audit"] = nil 
+        end 
+
 
         # Pick up hot2000 version number for this run, and
 
@@ -1268,7 +1273,7 @@ end
 
 $cmdlineopts = Hash.new
 $gTest_params = Hash.new        # test parameters
-$gTest_params["verbosity"] = "Lquiet"
+$gTest_params["verbosity"] = "quiet"
 $gOptionFile = ""
 $gSubstitutePath = "C:\/HTAP\/substitute-h2k.rb"
 $gWarn = "1"
@@ -1276,6 +1281,9 @@ $gOutputFile = "HTAP-prm-output.csv"
 $gOutputJSON = "HTAP-prm-output.json"
 $gFailFile = "HTAP-prm-failures.txt"
 $gSaveAllRuns = false
+
+
+$gTest_params["audit-costs"] = false
 
 $gRunDefinitionsProvided = false
 $gRunDefinitionsFile = ""
@@ -1350,6 +1358,11 @@ optparse = OptionParser.new do |opts|
 
    opts.on("-j", "--json", "Provide output in JSON format (htap-prm-output.json),","in additon to .csv.") do
       $gJSONize = true
+   end
+
+   opts.on("-a", "--include_audit_data", "Output progress to console.") do
+      $cmdlineopts["audit_data"] = true
+      $gTest_params["audit-costs"] = true
    end
 
 

--- a/htap-prm.rb
+++ b/htap-prm.rb
@@ -905,25 +905,17 @@ def run_these_cases(current_task_files)
         jsonParsed = false
         #debug_out "pp: \n#{$RunResults["run-#{thread3}"].pretty_inspect}\n"
         debug_out "Looking for #{$RunResultFilenameV2} ? \n"
+        
         if ( File.exist?($RunResultFilenameV2) ) then
           debug_out "Found it. Parsing JSON output !\n"
           contents = File.read($RunResultFilenameV2)
           thisRunResults = Hash.new
           thisRunResults = JSON.parse(contents)
 
+
           if ( ! $gTest_params["audit-costs"] ) then 
-            thisRunResults["costEstimates"]["audit"] = nil 
+            thisRunResults["cost-estimates"]["audit"] = nil 
           end 
-
-
-          #$RunResults["run-#{thread3}"]["output"] = thisRunResults["output"]
-          #$RunResults["run-#{thread3}"]["cost-estimates"] = thisRunResults["costEstimates"]
-          #$RunResults["run-#{thread3}"]["input"] = thisRunResults["input"]
-          #$RunResults["run-#{thread3}"]["archetype"] = thisRunResults["archetype"]
-
-
-          
-
 
           thisRunResults.keys.each do | section |
             if ( section.eql?("status") || section.eql?("configuration") ) then

--- a/substitute-h2k.rb
+++ b/substitute-h2k.rb
@@ -1905,6 +1905,13 @@ def processFile(h2kElements)
           # DHW System
           #--------------------------------------------------------------------------
         elsif ( choiceEntry =~ /Opt-DHWSystem/ )
+          myDHWChoice = $gChoices["Opt-DHWSystem"]
+          if myDHWChoice != "NA"
+            locationText = "HouseFile/House/Components/HotWater"
+            if (! h2kElements[locationText].elements["Secondary"].nil?)
+              h2kElements[locationText].delete_element("Secondary")
+            end
+          end
           if ( tag =~ /Opt-H2K-Fuel/ &&  value != "NA" )
             locationText = "HouseFile/House/Components/HotWater/Primary"
             if ( h2kElements[locationText].attributes["pilotEnergy"] == nil )


### PR DESCRIPTION
Small changes that: 
 a) address a bug preventing the ruler from being printed at the top of each HTAP run 
 b) add a switch to specify whether cost-audit data should be used in json output. ( `-a` to include data)