### PR TITLE
Merge of Rasoul;

### DIFF
--- a/HTAP-options.json
+++ b/HTAP-options.json
@@ -11165,7 +11165,17 @@
           }
         }
       },
-      "equal-on-all-sides_9.36": {
+		"Proposed-9.36": {
+        "h2kMap": {
+          "base": {
+            "OPT-H2K-FDWR": "NA",
+            "OPT-H2K-OVERHANG-WDTH": "NA",
+            "OPT-H2K-OVERHANG-HGHT": "NA",
+				"OPT-H2K-DISTRIBUTION": "NA"
+          }
+        }
+      },  
+      "Reference-9.36": {
         "h2kMap": {
           "base": {
             "OPT-H2K-FDWR": "NBC9.36",
@@ -11175,7 +11185,7 @@
           }
         }
       },
-		"equal-on-all-sides_mid-glazing": {
+		"Reference-mid-glazing": {
         "h2kMap": {
           "base": {
             "OPT-H2K-FDWR": "0.20",
@@ -11185,7 +11195,7 @@
           }
         }
       },
-		"equal-on-all-sides_high-glazing": {
+		"Reference-high-glazing": {
         "h2kMap": {
           "base": {
             "OPT-H2K-FDWR": "0.22",
@@ -11195,7 +11205,7 @@
           }
         }
       },
-		"proportional_mid-glazing": {
+		"Proposed-mid-glazing": {
         "h2kMap": {
           "base": {
             "OPT-H2K-FDWR": "0.20",
@@ -11205,7 +11215,7 @@
           }
         }
       },
-		"proportional_high-glazing": {
+		"Proposed-high-glazing": {
         "h2kMap": {
           "base": {
             "OPT-H2K-FDWR": "0.25",

--- a/htap-prm.rb
+++ b/htap-prm.rb
@@ -962,8 +962,8 @@ def run_these_cases(current_task_files)
 
           # Delete audit data unless it is requested. 
           if ( 
-               ! thisRunResults["cost-estimates"].empty? and 
-               ! thisRunResults["cost-estimates"]["audit"].empty? and 
+               ! thisRunResults["cost-estimates"].nil? and 
+               ! thisRunResults["cost-estimates"]["audit"].nil? and 
                ! $gTest_params["audit-costs"] 
             ) then 
           

--- a/include/H2KUtils.rb
+++ b/include/H2KUtils.rb
@@ -1306,6 +1306,7 @@ module H2KFile
     myH2KHouseInfo["house-description"] = Hash.new
     myH2KHouseInfo["house-description"]["stories"] = H2KFile.getStoreys(elements)
     myH2KHouseInfo["house-description"]["type"] = H2KFile.getHouseType(elements)
+	 myH2KHouseInfo["house-description"]["frontOrient"] = H2KFile.getFrontOrientation(elements) 
 
     # Dimensions
     myH2KHouseInfo["dimensions"] = Hash.new
@@ -1353,7 +1354,7 @@ module H2KFile
   def H2KFile.addWin(elements, facingDirection, height, width, overhangW, overhangH, winCode)
     # Facing direction codes for HOT2000
     windowFacingH2KVal = { "S" => 1, "SE" => 2, "E" => 3, "NE" => 4, "N" => 5, "NW" => 6, "W" => 7, "SW" => 8 }
-    useThisCodeID  = {  "S"  =>  191 ,    "SE" =>  192 ,    "E"  =>  193 ,    "NE" =>  194 ,    "N"  =>  195 ,    "NW" =>  196 ,    "W"  =>  197 ,    "SW" =>  198   }
+    useThisCodeID  = {  "S"  =>  291 ,    "SE" =>  292 ,    "E"  =>  293 ,    "NE" =>  294 ,    "N"  =>  295 ,    "NW" =>  296 ,    "W"  =>  297 ,    "SW" =>  298   }
     locationText = "HouseFile/House/Components/Wall"
     largestWallArea = 0.0
     idWall = "0"

--- a/include/rulesets.rb
+++ b/include/rulesets.rb
@@ -266,6 +266,7 @@ def NBC_936_2010_RuleSet( ruleType, ruleSpecs, elements, locale_HDD, cityName )
    $ruleSetChoices["Opt-Baseloads"] = "NBC-Baseloads"
    $ruleSetChoices["Opt-ResultHouseCode"] = "General"
    $ruleSetChoices["Opt-Temperatures"] = "NBC_Temps"
+   $ruleSetChoices["Opt-WindowDistribution"] = "Reference-9.36"
    if ($PermafrostHash[cityName] == "continuous")
       $ruleSetChoices["Opt-Specifications"] = "NBC_Specs_Perma"
       applyPermafrostRules = true

--- a/substitute-h2k.rb
+++ b/substitute-h2k.rb
@@ -242,6 +242,7 @@ costEstimates = Hash.new
 
 $ruleSetChoices = Hash.new
 $ruleSetName = ""
+$gRulesetSpecs = Hash.new
 
 $HDDs = ""
 
@@ -3208,8 +3209,8 @@ def processFile(h2kElements)
               # four square window
               equalWinSide = Math.sqrt(totalNewWinArea/4) * 1000.0
 
-              (1..4).each do |winOrient|
-                if (frontOrientation =~ /S/ || frontOrientation =~ /N/ || frontOrientation =~ /W/ || frontOrientation =~ /E/)
+            
+                if (frontOrientation == "S" || frontOrientation == "N" || frontOrientation == "W" || frontOrientation == "E")
                   newWinHeight[1] = equalWinSide
                   newWinHeight[3] = equalWinSide
                   newWinHeight[5] = equalWinSide
@@ -3229,7 +3230,7 @@ def processFile(h2kElements)
                   newWinWidth[8] = equalWinSide
                 end
 
-              end
+             
 
             elsif value == "PROPORTIONAL"
               #TBA
@@ -3244,7 +3245,7 @@ def processFile(h2kElements)
             # Obtain window codes
             h2kElements.each(locationTextWin) do |window|
               winOrient = window.elements["FacingDirection"].attributes["code"].to_i
-              tempAreaWin[winOrient] = window.elements["Measurements"].attributes["height"].to_f * window.elements["Measurements"].attributes["width"].to_f
+              tempAreaWin[winOrient] = window.elements["Measurements"].attributes["height"].to_f * window.elements["Measurements"].attributes["width"].to_f * window.attributes["number"].to_i
               if tempAreaWin[winOrient] > maxAreaWin[winOrient]
                 winCode[winOrient] = window.elements["Construction"].elements["Type"].attributes["idref"]
                 maxAreaWin[winOrient] = tempAreaWin[winOrient]
@@ -5869,6 +5870,7 @@ def ChangeWinCodeByOrient( winOrient, newValue, h2kCodeLibElements, h2kFileEleme
           $BuilderName  = H2KFile.getBuilderName(elements)
           $HouseType    = H2KFile.getHouseType(elements)
           $HouseStoreys = H2KFile.getStoreys(elements)
+			 $HouseFrontOrientation = H2KFile.getFrontOrientation(elements)
 
           locationText = "HouseFile/House/Components/Ceiling"
           areaCeiling_temp = 0.0
@@ -7096,6 +7098,7 @@ def ChangeWinCodeByOrient( winOrient, newValue, h2kCodeLibElements, h2kFileEleme
             conditionString = ""
             $ruleSetSpecs.each do | cond, value |
               conditionString = "; #{cond}=#{value}"
+              $gRulesetSpecs["#{cond}"] = "#{value}"
             end
 
             stream_out("\n\n Applying Ruleset #{ruleSet}#{conditionString}:\n")
@@ -7431,6 +7434,7 @@ def ChangeWinCodeByOrient( winOrient, newValue, h2kCodeLibElements, h2kFileEleme
             "House-Builder"       =>  "#{$BuilderName}",
             "House-Type"          =>  "#{$HouseType}",
             "House-Storeys"       =>  "#{$HouseStoreys}",
+			    	"Front-Orientation"   =>  "#{$HouseFrontOrientation}",
             "Weather-Locale"      =>  "#{$Locale_model}",
             "Base-Region"         =>  "#{$gBaseRegion}",
             "Base-Locale"         =>  "#{$gBaseLocale}",
@@ -7483,7 +7487,9 @@ def ChangeWinCodeByOrient( winOrient, newValue, h2kCodeLibElements, h2kFileEleme
             results[$aliasLongInput] = { "Run-Region" =>  "#{$gRunRegion}",
             "Run-Locale" =>  "#{$gRunLocale}",
             "House-Upgraded"   =>  "#{houseUpgraded}",
-            "House-ListOfUpgrades" => "#{houseUpgradeList}"
+            "House-ListOfUpgrades" => "#{houseUpgradeList}",
+            "Ruleset-Fuel-Source" => "#{$gRulesetSpecs["fuel"]}",
+            "Ruleset-Ventilation" => "#{$gRulesetSpecs["vent"]}"
           }
           $gChoices.sort.to_h
           for attribute in $gChoices.keys()
@@ -7607,6 +7613,7 @@ def ChangeWinCodeByOrient( winOrient, newValue, h2kCodeLibElements, h2kFileEleme
         $fSUMMARY.write( "#{$aliasArch}.House-Builder     =  #{$BuilderName}\n" )
         $fSUMMARY.write( "#{$aliasArch}.House-Type        =  #{$HouseType}\n" )
         $fSUMMARY.write( "#{$aliasArch}.House-Storeys     =  #{$HouseStoreys}\n" )
+		  $fSUMMARY.write( "#{$aliasArch}.Front-Orientation =  #{$HouseFrontOrientation}\n")
         $fSUMMARY.write( "#{$aliasArch}.Weather-Locale    =  #{$Locale_model}\n" )
         $fSUMMARY.write( "#{$aliasArch}.Base-Region       =  #{$gBaseRegion}\n" )
         $fSUMMARY.write( "#{$aliasArch}.Base-Locale       =  #{$gBaseLocale}\n" )


### PR DESCRIPTION
1. Update window re-distribution code (minor bug fixes)
2. Add window re-distribution to NBC9.36 ruleset
3. Add ruleset specs to the CSV report (Input|Ruleset-Fuel-Source and
Input|Ruleset-Ventilation)
4. Potential bug: When costing not reported prm generates an error
because of missing attribute. A quick fix seems to solved the problem.