### PR TITLE
Proposed merge of patch for encoding problems with Browse.Rpt

### DIFF
--- a/inc/H2KUtils.rb
+++ b/inc/H2KUtils.rb
@@ -1745,7 +1745,9 @@ module H2KOutput
 
 
     myBrowseData = {"monthly"=>Hash.new, "daily" => Hash.new, "annual" => Hash.new }
-    fBrowseRpt = File.new(myBrowseRptFile, "r", :encoding => 'Windows 1252' )
+    fBrowseRpt = File.new(myBrowseRptFile, "r")
+    # fBrowseRpt = File.new(myBrowseRptFile, "r", :encoding => 'UTF-8', :invalid=>:replace, :replace=>"?" )
+    # fBrowseRpt = File.new(myBrowseRptFile, "r", :encoding => 'UTF-16BE', :invalid=>:replace, :replace=>"?" )
    
     flagACPerf = false 
     flagSHPerf = false 
@@ -1758,7 +1760,11 @@ module H2KOutput
     $hourlyFoundACData = false 
 
     while !fBrowseRpt.eof? do
-      line = fBrowseRpt.readline
+      #line = fBrowseRpt.readline
+
+      #line = fBrowseRpt.readline.encode("UTF-8", :invalid=>:replace, :replace=>"?")
+      line = fBrowseRpt.readline.encode("UTF-8",  :invalid=>:replace, :replace=>"?" )      
+
       # Sequentially read file lines
       line.strip!
       # Remove leading and trailing whitespace

--- a/inc/H2KUtils.rb
+++ b/inc/H2KUtils.rb
@@ -1773,6 +1773,10 @@ module H2KOutput
 
       # ==============================================================
       # Heating section 
+
+      debug_on
+      debug_out ("E3 line: #{line} \n")
+     debug_off
       if ( line =~ /\*\*\* SPACE HEATING SYSTEM PERFORMANCE \*\*\*/ )
         myBrowseData["monthly"]["heating"] = {"loadGJ" => Hash.new, 
                                               "input_energyGJ" => Hash.new,

--- a/inc/H2KUtils.rb
+++ b/inc/H2KUtils.rb
@@ -1745,9 +1745,8 @@ module H2KOutput
 
 
     myBrowseData = {"monthly"=>Hash.new, "daily" => Hash.new, "annual" => Hash.new }
-    fBrowseRpt = File.new(myBrowseRptFile, "r")
-
-
+    fBrowseRpt = File.new(myBrowseRptFile, "r", :encoding => 'Windows 1252' )
+   
     flagACPerf = false 
     flagSHPerf = false 
     flagSRPerf = false 
@@ -1774,9 +1773,6 @@ module H2KOutput
       # ==============================================================
       # Heating section 
 
-      debug_on
-      debug_out ("E3 line: #{line} \n")
-     debug_off
       if ( line =~ /\*\*\* SPACE HEATING SYSTEM PERFORMANCE \*\*\*/ )
         myBrowseData["monthly"]["heating"] = {"loadGJ" => Hash.new, 
                                               "input_energyGJ" => Hash.new,

--- a/substitute-h2k.rb
+++ b/substitute-h2k.rb
@@ -5310,24 +5310,30 @@ def ChangeWinCodeByOrient( winOrient, newValue, h2kCodeLibElements, h2kFileEleme
         end
 
         # Parse Rpt file ?
+        debug_on
         begin  
 
-          debug_out "Parsing browse.rpt"
+          debug_out "Parsing browse.rpt - 1 \n "
           dataFromBrowse = H2KOutput.parse_BrowseRpt("#{$OutputFolder}\\Browse.Rpt")
           #debug_out "RESULT-> \n #{dataFromBrowse.pretty_inspect}\n"
            
         rescue 
           warn_out ("Could not parse #{$OutputFolder}\\Browse.Rpt. Trying again!\n")
           sleep 2.0
+          debug_out("Parsing browse.rpt - 2 \n ")
           dataFromBrowse = H2KOutput.parse_BrowseRpt("#{$OutputFolder}\\Browse.Rpt")
         end 
-
+        debug_off
         # Read from Browse.rpt ASCII file *if* data not available in XML (.h2k file)!
         if bReadOldERSValue || bReadAirConditioningLoad || $PVIntModel
           begin
+            debug_on
+            debug_out "Parsing browse.rpt - 3 \n"
+            debug_off
             fBrowseRpt = File.new("#{$OutputFolder}\\Browse.Rpt", "r")
             while !fBrowseRpt.eof? do
-              lineIn = fBrowseRpt.readline
+
+              lineIn = fBrowseRpt.readline.encode("UTF-8",  :invalid=>:replace, :replace=>"?" ) 
               # Sequentially read file lines
               lineIn.strip!
               # Remove leading and trailing whitespace

--- a/substitute-h2k.rb
+++ b/substitute-h2k.rb
@@ -5317,7 +5317,9 @@ def ChangeWinCodeByOrient( winOrient, newValue, h2kCodeLibElements, h2kFileEleme
           #debug_out "RESULT-> \n #{dataFromBrowse.pretty_inspect}\n"
            
         rescue 
-          warn_out ("Could not parse #{$OutputFolder}\\Browse.Rpt!\n")
+          warn_out ("Could not parse #{$OutputFolder}\\Browse.Rpt. Trying again!\n")
+          sleep 2.0
+          dataFromBrowse = H2KOutput.parse_BrowseRpt("#{$OutputFolder}\\Browse.Rpt")
         end 
 
         # Read from Browse.rpt ASCII file *if* data not available in XML (.h2k file)!

--- a/substitute-h2k.rb
+++ b/substitute-h2k.rb
@@ -5025,7 +5025,7 @@ def ChangeWinCodeByOrient( winOrient, newValue, h2kCodeLibElements, h2kFileEleme
         $lineNo = 0
         if ( $gReadROutStrTxt  )
           #begin
-          stream_out("\nParsing diagnostics from #{$OutputFolder}\\Routstr.txt ...")
+          stream_out("\n Parsing diagnostics from #{$OutputFolder}\\Routstr.txt ...")
           fRoutStr = File.new("#{$OutputFolder}\\Routstr.txt", "r")
 
           $SOCparse     = false
@@ -5310,24 +5310,24 @@ def ChangeWinCodeByOrient( winOrient, newValue, h2kCodeLibElements, h2kFileEleme
         end
 
         # Parse Rpt file ?
-        debug_on
+
         begin  
 
           debug_out "Parsing browse.rpt - 1 \n "
           dataFromBrowse = H2KOutput.parse_BrowseRpt("#{$OutputFolder}\\Browse.Rpt")
+          log_out("Parsed Browse.Rpt produced error.")
           #debug_out "RESULT-> \n #{dataFromBrowse.pretty_inspect}\n"
            
         rescue 
-          warn_out ("Could not parse #{$OutputFolder}\\Browse.Rpt. Trying again!\n")
-          sleep 2.0
-          debug_out("Parsing browse.rpt - 2 \n ")
-          dataFromBrowse = H2KOutput.parse_BrowseRpt("#{$OutputFolder}\\Browse.Rpt")
+          warn_out ("Could not parse #{$OutputFolder}\\Browse.Rpt!\n")
+          log_out("Parsing Browse.Rpt produced error. Check encoding.")
         end 
-        debug_off
+
         # Read from Browse.rpt ASCII file *if* data not available in XML (.h2k file)!
+        # This code should be migrated inside parse_BrowseRPT. 
         if bReadOldERSValue || bReadAirConditioningLoad || $PVIntModel
           begin
-            debug_on
+
             debug_out "Parsing browse.rpt - 3 \n"
             debug_off
             fBrowseRpt = File.new("#{$OutputFolder}\\Browse.Rpt", "r")


### PR DESCRIPTION
Some combinations of ruby and HOT2000 produced a perplexing error - "Could not parse Browse.RPT".  These seem to be related to mismatches between encoding supported by various versions of Ruby, and non-UTF-8 characters that HOT2000 arbitrarily dumps into the Browse.Rpt file. These changes patch that error by forcing encoding to UTF8. 