### PR TITLE
Changes to HTAP2H2K.conf_foundations and H2KFile.updBsmCrawlDef

### DIFF
--- a/inc/H2KUtils.rb
+++ b/inc/H2KUtils.rb
@@ -13,7 +13,6 @@ module HTAP2H2K
 
     debug_out "Setting up foundations for this config:\n#{myFdnData.pretty_inspect}\n"
 
-    slabConfigInsulated = "SCB_25"
     # Insulation configuration on slabs -
     #  Pretty sure requirements are that 9.25.2.3 (5) requires SBC 25 and 29.
     #
@@ -36,6 +35,7 @@ module HTAP2H2K
     #       ********                     ********
     #
     slabConfigInsulated = "SCB_25"
+    slabConfigUninsulated = "SCN_1"
 
     h2kFdnData = Hash.new
 
@@ -57,6 +57,7 @@ module HTAP2H2K
       bExtWallInsul = true if ( HTAPData.getResultsForChoice(myOptions,"Opt-FoundationWallExtIns",myFdnData["FoundationWallExtIns"])["H2K-Fdn-ExtWallReff"].to_f > 0.01 )
       bIntWallInsul = true if ( HTAPData.getResultsForChoice(myOptions,"Opt-FoundationWallIntIns",myFdnData["FoundationWallIntIns"])["H2K-Fdn-IntWallReff"].to_f > 0.01 )
       bBGSlabInsul =  true if ( HTAPData.getResultsForChoice(myOptions,"Opt-FoundationSlabBelowGrade",myFdnData["FoundationSlabBelowGrade"])["H2K-Fdn-SlabBelowGradeReff"].to_f > 0.01 )
+      bOGSlabInsul =  true if ( HTAPData.getResultsForChoice(myOptions,"Opt-FoundationSlabOnGrade",myFdnData["FoundationSlabOnGrade"])["H2K-Fdn-SlabOnGradeReff"].to_f > 0.01 )
 
 
 
@@ -68,12 +69,11 @@ module HTAP2H2K
 
       debug_out(drawRuler("Basements, CrawlSpaces",". "))
 
-      # Where is the insulation ?
+      # Where is the insulation ? Sort basements first
       #
       # [  ] exterior     [   ] Interior      [  ] Slab  (None! )
       if  ( ! bExtWallInsul && ! bIntWallInsul && ! bBGSlabInsul ) then
         basementConfig = "BCNN_2"
-        crawlSpaceConfig = "SCN_1"
         h2kFdnData["?bgSlabIns"]  = false
         h2kFdnData["?IntWallIns"] = false
         h2kFdnData["?ExtWallIns"] = false
@@ -82,7 +82,6 @@ module HTAP2H2K
         # [ X ] exterior     [   ] Interior      [  ] Slab  ( full height exterior)
       elsif  ( bExtWallInsul && ! bIntWallInsul && ! bBGSlabInsul ) then
         basementConfig = "BCEN_2"
-        crawlSpaceConfig = "SCN_1"
         h2kFdnData["?bgSlabIns"]  = false
         h2kFdnData["?IntWallIns"] = false
         h2kFdnData["?ExtWallIns"] = true
@@ -91,7 +90,6 @@ module HTAP2H2K
       elsif  ( ! bExtWallInsul &&  bIntWallInsul && ! bBGSlabInsul ) then
 
         basementConfig = "BCIN_1"
-        crawlSpaceConfig = "SCN_1"
         h2kFdnData["?bgSlabIns"]  = false
         h2kFdnData["?IntWallIns"] = true
         h2kFdnData["?ExtWallIns"] = false
@@ -100,7 +98,6 @@ module HTAP2H2K
       elsif  ( bExtWallInsul && bIntWallInsul && ! bBGSlabInsul ) then
 
         basementConfig = "BCCN_5"
-        crawlSpaceConfig = "SCN_1"
         h2kFdnData["?bgSlabIns"]  = false
         h2kFdnData["?IntWallIns"] = true
         h2kFdnData["?ExtWallIns"] = true
@@ -109,7 +106,6 @@ module HTAP2H2K
       elsif  (  bExtWallInsul && ! bIntWallInsul &&  bBGSlabInsul ) then
 
         basementConfig = "BCEB_4"
-        crawlSpaceConfig = slabConfigInsulated
         # (SCB_29, SCB_31 would give better thermal separation - not sure which to use... )
 
         h2kFdnData["?bgSlabIns"]  = true
@@ -121,7 +117,6 @@ module HTAP2H2K
       elsif  ( ! bExtWallInsul &&  bIntWallInsul &&  bBGSlabInsul ) then
 
         basementConfig = "BCIB_1"
-        crawlSpaceConfig = slabConfigInsulated
         # (SCB_29, SCB_31 would give better thermal separation - not sure which to use... )
 
         h2kFdnData["?bgSlabIns"]  = true
@@ -133,7 +128,6 @@ module HTAP2H2K
       elsif  (  bExtWallInsul &&  bIntWallInsul &&  bBGSlabInsul ) then
 
         basementConfig = "BCCB_9"
-        crawlSpaceConfig = slabConfigInsulated
         # (SCB_29, SCB_31 would give better thermal separation - not sure which to use... )
 
         h2kFdnData["?bgSlabIns"]  = true
@@ -144,6 +138,15 @@ module HTAP2H2K
         # Need to make this case more general?
         fatalerror ("Unsupported foundation configuration!!!")
       end
+      
+      # Sort the slab-on-grade configurations
+      if (bOGSlabInsul) then
+        crawlSpaceConfig = slabConfigInsulated
+        h2kFdnData["?ogSlabIns"]  = true
+      else
+        crawlSpaceConfig = slabConfigUninsulated
+        h2kFdnData["?ogSlabIns"]  = false
+      end
 
       debug_out " Basement/crawlspace configuration : #{basementConfig}\n"
       h2kFdnData["BasementConfig"] = basementConfig
@@ -151,6 +154,7 @@ module HTAP2H2K
       h2kFdnData["rEffIntWall"] =  myOptions["Opt-FoundationWallIntIns"]["options"][rEff_IntWall]["values"]["1"]["conditions"]["all"].to_f
       h2kFdnData["rEffExtWall"] =  myOptions["Opt-FoundationWallExtIns"]["options"][rEff_ExtWall]["values"]["1"]["conditions"]["all"].to_f
       h2kFdnData["rEff_SlabBG"] =  myOptions["Opt-FoundationSlabBelowGrade"]["options"][rEff_SlabBG]["values"]["1"]["conditions"]["all"].to_f
+      h2kFdnData["rEff_SlabOG"] =  myOptions["Opt-FoundationSlabOnGrade"]["options"][rEff_SlabOG]["values"]["1"]["conditions"]["all"].to_f
 
       debug_out "Processing basements/crawlspaces with following specs:\n#{h2kFdnData.pretty_inspect}"
 
@@ -280,7 +284,6 @@ module H2KFile
         debug_out(" ... crawlspace code \n")
         config_type = fdnData["CrawlConfig"].split(/_/)[0]
         config_subtype= fdnData["CrawlConfig"].split(/_/)[1]
-
       end
 
       debug_out(" setting configuration to #{config_type}, subtype #{config_subtype}\n")
@@ -290,8 +293,14 @@ module H2KFile
       node.elements[loc].attributes["subtype"] = config_subtype
 
       node.elements[loc].attributes["overlap"] = "0" if ( node.name == "Basement" )
-
-      node.elements[loc].text = fdnData["configuration"]
+      
+      if (  node.name == "Basement" ) then
+        node.elements[loc].text = fdnData["BasementConfig"]
+      elsif ( node.name == "Crawlspace" ) then
+        node.elements[loc].text = fdnData["CrawlConfig"]
+      else
+        puts "TODO: Error handling here line 302"
+      end
 
       loc = ".//Floor/Construction"
       node.elements[loc].attributes["isBelowFrostline"] = "true"
@@ -372,20 +381,23 @@ module H2KFile
       loc = ".//Floor/Construction"
       node.elements["#{loc}"].attributes["heatedFloor"] = 'false'
       node.elements[loc].elements.delete("AddedToSlab")
-      if ( !  fdnData["?bgSlabIns"] ) then
-
-      else
-        debug_out "Adding definitions for under-slab insulation\n"
-        #node.elements["#{loc}/Composite"].elements.each do | section |
-
-        node.elements[loc].elements.add("AddedToSlab")
-        node.elements["#{loc}/AddedToSlab"].text = "User Specified"
-        node.elements["#{loc}/AddedToSlab"].attributes["nominalInsulation"] = "#{((fdnData["rEff_SlabBG"].to_f + 1.0)/R_PER_RSI).round(4)}"
-        #HOT2000 v11.58 expects rValue - but values set to RSI ?!?! - possible h2k bug.
-        node.elements["#{loc}/AddedToSlab"].attributes["rValue"] = "#{((fdnData["rEff_SlabBG"].to_f)/R_PER_RSI).round(4)}"
+      if ( node.name == "Basement" && fdnData["?bgSlabIns"] ) then
+          debug_out "Adding definitions for under-slab insulation for basement\n"
+    
+          node.elements[loc].elements.add("AddedToSlab")
+          node.elements["#{loc}/AddedToSlab"].text = "User Specified"
+          node.elements["#{loc}/AddedToSlab"].attributes["nominalInsulation"] = "#{((fdnData["rEff_SlabBG"].to_f + 1.0)/R_PER_RSI).round(4)}"
+          #HOT2000 v11.58 expects rValue - but values set to RSI ?!?! - possible h2k bug.
+          node.elements["#{loc}/AddedToSlab"].attributes["rValue"] = "#{((fdnData["rEff_SlabBG"].to_f)/R_PER_RSI).round(4)}"
+      elsif ( node.name == "Crawlspace" && fdnData["?ogSlabIns"]) then
+          debug_out "Adding definitions for under-slab insulation for crawlspace\n"
+    
+          node.elements[loc].elements.add("AddedToSlab")
+          node.elements["#{loc}/AddedToSlab"].text = "User Specified"
+          node.elements["#{loc}/AddedToSlab"].attributes["nominalInsulation"] = "#{((fdnData["rEff_SlabOG"].to_f + 1.0)/R_PER_RSI).round(4)}"
+          #HOT2000 v11.58 expects rValue - but values set to RSI ?!?! - possible h2k bug.
+          node.elements["#{loc}/AddedToSlab"].attributes["rValue"] = "#{((fdnData["rEff_SlabOG"].to_f)/R_PER_RSI).round(4)}"
       end
-
-
 
     end
 
@@ -854,7 +866,7 @@ module H2KFile
   end  # function get Ceiling area.
 
   # =========================================================================================
-  # Get primary heating system type and fuel
+  # Get primary heating system fuel
   # =========================================================================================
   def H2KFile.getPrimaryHeatSys(elements)
 
@@ -876,6 +888,26 @@ module H2KFile
     end
 
     return fuelName
+  end
+  
+  # =========================================================================================
+  # Get primary heating system type
+  # =========================================================================================
+  def H2KFile.getPrimaryHeatSysType(elements)
+    sysType1 = ""
+    if elements["HouseFile/House/HeatingCooling/Type1/Baseboards"] != nil
+      sysType1 = "Baseboards"
+    elsif elements["HouseFile/House/HeatingCooling/Type1/Furnace"] != nil
+      sysType1 = "Furnace"
+    elsif elements["HouseFile/House/HeatingCooling/Type1/Boiler"] != nil
+      sysType1 = "Boiler"
+    elsif elements["HouseFile/House/HeatingCooling/Type1/ComboHeatDhw"] != nil
+      sysType1 = "Combo"
+    elsif elements["HouseFile/House/HeatingCooling/Type1/P9"] != nil
+      sysType1 = "P9"
+    end
+
+    return sysType1
   end
 
   # =========================================================================================
@@ -899,7 +931,7 @@ module H2KFile
   end
 
   # =========================================================================================
-  # Get primary DHW system type and fuel
+  # Get primary DHW system fuel
   # =========================================================================================
   def H2KFile.getPrimaryDHWSys(elements)
 
@@ -907,6 +939,17 @@ module H2KFile
     #tankType1 = elements["HouseFile/House/Components/HotWater/Primary/TankType"].attributes["code"]
 
     return fuelName
+  end
+  
+  # =========================================================================================
+  # Get primary DHW system type and fuel
+  # =========================================================================================
+  def H2KFile.getPrimaryDHWSysTankType(elements)
+
+    sTankType = elements["HouseFile/House/Components/HotWater/Primary/TankType/English"].text
+    sTankType=sTankType.to_s
+
+    return sTankType.strip
   end
 
   # ======================================================================================
@@ -2607,7 +2650,12 @@ module H2KOutput
         myResults[houseCode]["avgVntAirChangeRateTotal"] = element.elements[".//Annual/AirChangeRate"].attributes["total"].to_f  
         myResults[houseCode]["avgSolarGainsUtilized"] = element.elements[".//Annual/UtilizedSolarGains"].attributes["value"].to_f  
         myResults[houseCode]["avgVntMinAirChangeRate"] = element.elements[".//Other/Ventilation"].attributes["minimumAirChangeRate"].to_f  
-
+        # Process useful gains
+        monthArr = [ "january", "february", "march", "april", "may", "june", "july", "august", "september", "october", "november", "december" ]
+        myResults[houseCode]["avgInternalGainsUtilized"] = 0.0
+        monthArr.each do |mth|
+            myResults[houseCode]["avgInternalGainsUtilized"] += element.elements[".//Monthly/Gains/UtilizedInternal"].attributes[mth].to_f / 1000.0
+        end
         myResults[houseCode]["avgFuelCostsElec$"]    = element.elements[".//Annual/ActualFuelCosts"].attributes["electrical"].to_f  
         myResults[houseCode]["avgFuelCostsNatGas$"]  = element.elements[".//Annual/ActualFuelCosts"].attributes["naturalGas"].to_f  
         myResults[houseCode]["avgFuelCostsOil$"]     = element.elements[".//Annual/ActualFuelCosts"].attributes["oil"].to_f  
@@ -2673,7 +2721,7 @@ module H2KOutput
 
       
 
-        monthArr = [ "january", "february", "march", "april", "may", "june", "july", "august", "september", "october", "november", "december" ]
+        # monthArr = [ "january", "february", "march", "april", "may", "june", "july", "august", "september", "october", "november", "december" ]
         debug_out (" Picking up  AUX energy requirement from each result set. \n")
 
         $gAuxEnergyHeatingGJ = 0


### PR DESCRIPTION
When using the surface-by-surface definition for foundation insulation it was found that heated crawlspaces only had their wall insulation updated and not the slab-on-grade. This update works as follows:
    - If the crawlspace is unheated the component isn't updated (floor above is updated via Opt-ExposedFloor)
    - If the crawlspace is heated and slab-on-grade is insulated the configuration is set to SCB_25:
        - Slab insulation is set to slab-on-grade insulation input provided
        - Wall insulation is the sum of foundation wall interior and exterior insulation
    - If the crawlspace is heated and slab-on-grade is uninsulated the configuration is set to SCN_1:
        - Wall insulation is the sum of foundation wall interior and exterior insulation