### PR TITLE
Several Updates to NBC Ruleset

### DIFF
--- a/HTAP-options.json
+++ b/HTAP-options.json
@@ -7115,6 +7115,30 @@
           "proxy": "xps2.5inEffR12.5"
         }
       },
+      "NBC_936_2.32RSI": {
+        "h2kMap": {
+          "base": {
+            "H2K-Fdn-SlabBelowGradeReff": "13.17"
+          }
+        },
+        "costs": {
+          "custom-costs": {
+          },
+          "proxy": "xps2.5inEffR12.5"
+        }
+      },
+      "NBC_936_2.84RSI": {
+        "h2kMap": {
+          "base": {
+            "H2K-Fdn-SlabBelowGradeReff": "16.13"
+          }
+        },
+        "costs": {
+          "custom-costs": {
+          },
+          "proxy": "xps2.5inEffR12.5"
+        }
+      },
       "NBC_936_4.44RSI": {
         "h2kMap": {
           "base": {
@@ -7308,6 +7332,30 @@
         "h2kMap": {
           "base": {
             "H2K-Fdn-SlabBelowGradeReff": "11.13"
+          }
+        },
+        "costs": {
+          "custom-costs": {
+          },
+          "proxy": "xps2.5inEffR12.5"
+        }
+      },
+      "NBC_936_2.32RSI": {
+        "h2kMap": {
+          "base": {
+            "H2K-Fdn-SlabBelowGradeReff": "13.17"
+          }
+        },
+        "costs": {
+          "custom-costs": {
+          },
+          "proxy": "xps2.5inEffR12.5"
+        }
+      },
+      "NBC_936_2.84RSI": {
+        "h2kMap": {
+          "base": {
+            "H2K-Fdn-SlabBelowGradeReff": "16.13"
           }
         },
         "costs": {
@@ -7511,6 +7559,18 @@
           "proxy": "xps2.5inEffR12.5"
         }
       },
+      "NBC_936_2.32RSI": {
+        "h2kMap": {
+          "base": {
+            "H2K-Fdn-SlabOnGradeReff": "13.17"
+          }
+        },
+        "costs": {
+          "custom-costs": {
+          },
+          "proxy": "xps2.5inEffR12.5"
+        }
+      },
       "NBC_936_2.84RSI": {
         "h2kMap": {
           "base": {
@@ -7527,6 +7587,18 @@
         "h2kMap": {
           "base": {
             "H2K-Fdn-SlabOnGradeReff": "21.13"
+          }
+        },
+        "costs": {
+          "custom-costs": {
+          },
+          "proxy": "xps4.5inEffR22.5"
+        }
+      },
+      "NBC_936_4.44RSI": {
+        "h2kMap": {
+          "base": {
+            "H2K-Fdn-SlabOnGradeReff": "25.22"
           }
         },
         "costs": {
@@ -9693,83 +9765,6 @@
           "components": []
         }
       },
-      
-      
-      "BaseExpFloor-R31": {
-        "h2kMap": {
-          "base": {
-            "OPT-H2K-CodeName": "NA",
-            "OPT-H2K-EffRValue": "31"
-          }
-        },
-        "costs": {
-          "custom-costs": {
-          },
-          "components": [
-				"insulation:r31_batt"
-          ]
-        }
-      },
-      "ExpFloorFlash&Batt-R36": {
-        "h2kMap": {
-          "base": {
-            "OPT-H2K-CodeName": "NA",
-            "OPT-H2K-EffRValue": "36"
-          }
-        },
-        "costs": {
-          "custom-costs": {
-          },
-          "components": [
-				"insulation:spray_foam_2pd_urethane:5.5in_thickness"
-          ]
-        }
-      },
-      "ExpFloorFoamed-R52": {
-        "h2kMap": {
-          "base": {
-            "OPT-H2K-CodeName": "Foamed-R52",
-            "OPT-H2K-EffRValue": "NA"
-          }
-        },
-        "costs": {
-          "custom-costs": {
-          },
-          "components": [
-				"insulation:spray_foam:2pound_urethane:7.5in_thickness",
-				"insulation:spray_foam:38mm:r6/inch"
-          ]
-        }
-      },
-      "NWTCrawlFlr": {
-        "h2kMap": {
-          "base": {
-            "OPT-H2K-CodeName": "NA",
-            "OPT-H2K-EffRValue": "30"
-          }
-        },
-        "costs": {
-          "custom-costs": {
-          },
-          "components": [
-
-          ]
-        }
-      },
-      "VintageR30": {
-        "h2kMap": {
-          "base": {
-            "OPT-H2K-CodeName": "NA",
-            "OPT-H2K-EffRValue": "32"
-          }
-        },
-        "costs": {
-          "custom-costs": {},
-          "components": []
-        }
-      },
-      
-      
       "BaseExpFloor-R31": {
         "h2kMap": {
           "base": {
@@ -10929,6 +10924,28 @@
           "proxy": "gas-furnace-psc"
         }
       },
+      "NBC2020-gas-boiler": {
+        "h2kMap": {
+          "base": {
+            "Opt-H2K-SysType1": "Boiler",
+            "Opt-H2K-SysType2": "None",
+            "Opt-H2K-Type1Fuel": "2",
+            "Opt-H2K-Type1EqpType": "5",
+            "Opt-H2K-Type1CapOpt": "2",
+            "Opt-H2K-Type1CapVal": "NA",
+            "Opt-H2K-Type1EffType": "false",
+            "Opt-H2K-Type1EffVal": "90",
+            "Opt-H2K-Type1FanCtl": "1",
+            "Opt-H2K-Type1IsRadiant": "true",
+            "Opt-H2K-Type1EEMotor": "false"
+          }
+        },
+        "costs": {
+          "custom-costs": {
+          },
+          "proxy": "gas-furnace-psc"
+        }
+      },
       "NBC-gas-furnace-AC": {
         "h2kMap": {
           "base": {
@@ -11506,7 +11523,8 @@
       "Opt-H2K-P9-elecUse100",
       "Opt-H2K-P9-blowPower15",
       "Opt-H2K-P9-blowPower40",
-      "Opt-H2K-P9-blowPower100"
+      "Opt-H2K-P9-blowPower100",
+      "Opt-H2K-Type1IsRadiant"
     ]
   },
   "Opt-HRVspec": {
@@ -12377,6 +12395,63 @@
             "Opt-H2K-TankSize": "189.3",
             "Opt-H2K-EF": "0.9",
             "Opt-H2K-IntHeatPumpCOP": "2.33",
+            "Opt-H2K-FlueDiameter": "NA"
+          }
+        },
+        "costs": {
+          "custom-costs": {
+          },
+          "components": [
+            "dhw_heat_pump_water_heater:50_gal:ef_2.35"
+          ]
+        }
+      },
+      "HotWater_hp_EF_2_35": {
+        "h2kMap": {
+          "base": {
+            "Opt-H2K-Fuel": "1",
+            "Opt-H2K-TankType": "7",
+            "Opt-H2K-TankSize": "189.3",
+            "Opt-H2K-EF": "0.9",
+            "Opt-H2K-IntHeatPumpCOP": "2.61",
+            "Opt-H2K-FlueDiameter": "NA"
+          }
+        },
+        "costs": {
+          "custom-costs": {
+          },
+          "components": [
+            "dhw_heat_pump_water_heater:50_gal:ef_2.35"
+          ]
+        }
+      },
+      "NBC-HotWater_hp_v118Workaround": {
+        "h2kMap": {
+          "base": {
+            "Opt-H2K-Fuel": "1",
+            "Opt-H2K-TankType": "7",
+            "Opt-H2K-TankSize": "189.3",
+            "Opt-H2K-EF": "0.9",
+            "Opt-H2K-IntHeatPumpCOP": "1.75",
+            "Opt-H2K-FlueDiameter": "NA"
+          }
+        },
+        "costs": {
+          "custom-costs": {
+          },
+          "components": [
+            "dhw_heat_pump_water_heater:50_gal:ef_2.35"
+          ]
+        }
+      },
+      "HotWater_hp_EF_2_35_v118Workaround": {
+        "h2kMap": {
+          "base": {
+            "Opt-H2K-Fuel": "1",
+            "Opt-H2K-TankType": "7",
+            "Opt-H2K-TankSize": "189.3",
+            "Opt-H2K-EF": "0.9",
+            "Opt-H2K-IntHeatPumpCOP": "1.62",
             "Opt-H2K-FlueDiameter": "NA"
           }
         },

--- a/inc/H2KUtils.rb
+++ b/inc/H2KUtils.rb
@@ -1548,7 +1548,10 @@ module H2KFile
         warn_out "Unknown whole house ventilation type #{ventsys.name}\n"
       end
     end
-    systemInfo["designLoads"] = H2KFile.getDesignLoads( elements )
+
+    unless elements["HouseFile/AllResults"].nil?
+        systemInfo["designLoads"] = H2KFile.getDesignLoads( elements )
+    end
 
     return systemInfo
 

--- a/substitute-h2k.rb
+++ b/substitute-h2k.rb
@@ -2177,6 +2177,35 @@ def processFile(h2kElements)
               end
             end
 
+          elsif ( tag =~ /Opt-H2K-Type1IsRadiant/ &&  value != "NA" )
+            if( value == "true")
+              # Type one system is radiant. Add the relevant data
+              h2kElements["HouseFile/House/HeatingCooling"].add_element("RadiantHeating")
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating"].add_element("AtticCeiling")
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating/AtticCeiling"].attributes["effectiveTemperature"] = "31"
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating/AtticCeiling"].attributes["fractionOfArea"] = "0"
+
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating"].add_element("FlatRoof")
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating/FlatRoof"].attributes["effectiveTemperature"] = "31"
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating/FlatRoof"].attributes["fractionOfArea"] = "0"
+              
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating"].add_element("AboveCrawlspace")
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating/AboveCrawlspace"].attributes["effectiveTemperature"] = "33"
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating/AboveCrawlspace"].attributes["fractionOfArea"] = "90"
+              
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating"].add_element("SlabOnGrade")
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating/SlabOnGrade"].attributes["effectiveTemperature"] = "33"
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating/SlabOnGrade"].attributes["fractionOfArea"] = "90"
+              
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating"].add_element("AboveBasement")
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating/AboveBasement"].attributes["effectiveTemperature"] = "33"
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating/AboveBasement"].attributes["fractionOfArea"] = "90"
+              
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating"].add_element("Basement")
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating/Basement"].attributes["effectiveTemperature"] = "33"
+              h2kElements["HouseFile/House/HeatingCooling/RadiantHeating/Basement"].attributes["fractionOfArea"] = "90"
+
+            end
           elsif ( tag =~ /Opt-H2K-Type1CapOpt/ &&  value != "NA" )
             sysType1.each do |sysType1Name|
               if ( sysType1Name != "P9" )

--- a/substitute-h2k.rb
+++ b/substitute-h2k.rb
@@ -698,6 +698,40 @@ def processFile(h2kElements)
 
             h2kElements[locationText].attributes["isCgsbTest"] = "true"
             h2kElements[locationText].attributes["isCalculated"] = "true"
+          elsif( tag =~ /Opt-NLR/ && value != "NA" )
+            # Need to set the House/AirTightnessTest code attribute to "Blower door test values" (x)
+            locationText = "HouseFile/House/NaturalAirInfiltration/Specifications/House/AirTightnessTest"
+            h2kElements[locationText].attributes["code"] = "x"
+            # Must also remove "Air Leakage Test Data" section, if present, since it will over-ride user-specified ACH value
+            locationText = "HouseFile/House/NaturalAirInfiltration/AirLeakageTestData"
+            if ( h2kElements[locationText] != nil )
+              # Need to remove this section!
+              locationText = "HouseFile/House/NaturalAirInfiltration"
+              h2kElements[locationText].delete_element("AirLeakageTestData")
+              # Change CGSB attribute to true (was set to "As Operated" by AirLeakageTestData section
+              locationText = "HouseFile/House/NaturalAirInfiltration/Specifications/BlowerTest"
+              h2kElements[locationText].attributes["isCgsbTest"] = "true"
+            end
+            # Retrieve house volume and exterior surface area
+            fThisVolume = h2kElements["HouseFile/House/NaturalAirInfiltration/Specifications/House"].attributes["volume"].to_f
+            fExtSurfArea = h2kElements["HouseFile/AllResults/Results/Other/GrossArea"].attributes["ceiling"].to_f
+            fExtSurfArea += h2kElements["HouseFile/AllResults/Results/Other/GrossArea"].attributes["exposedFloors"].to_f
+            fExtSurfArea += h2kElements["HouseFile/AllResults/Results/Other/GrossArea"].attributes["slab"].to_f
+            fExtSurfArea += h2kElements["HouseFile/AllResults/Results/Other/GrossArea"].attributes["ponyWall"].to_f
+            fExtSurfArea += h2kElements["HouseFile/AllResults/Results/Other/GrossArea/MainFloors"].attributes["mainWalls"].to_f
+            fExtSurfArea += h2kElements["HouseFile/AllResults/Results/Other/GrossArea/Basement"].attributes["aboveGrade"].to_f
+            fExtSurfArea += h2kElements["HouseFile/AllResults/Results/Other/GrossArea/Basement"].attributes["belowGrade"].to_f
+            fExtSurfArea += h2kElements["HouseFile/AllResults/Results/Other/GrossArea/Basement"].attributes["floorSlab"].to_f
+            fExtSurfArea += h2kElements["HouseFile/AllResults/Results/Other/GrossArea/Basement"].attributes["floorHeader"].to_f
+            fExtSurfArea += h2kElements["HouseFile/AllResults/Results/Other/GrossArea/Crawlspace"].attributes["floor"].to_f
+            if(h2kElements["HouseFile/House/Temperatures/Crawlspace"].attributes["heated"] == "true")
+                fExtSurfArea += h2kElements["HouseFile/AllResults/Results/Other/GrossArea/Crawlspace"].attributes["wall"].to_f
+            end
+            fThisACH = 3.6*(fExtSurfArea/fThisVolume)*value.to_f
+            
+            locationText = "HouseFile/House/NaturalAirInfiltration/Specifications/BlowerTest"
+            h2kElements[locationText].attributes["airChangeRate"] = sprintf("%0.3f", fThisACH)
+
           elsif( tag =~ /Opt-BuildingSite/ && value != "NA" )
             if(value.to_f < 1 || value.to_f > 8)
               fatalerror("In #{choiceEntry}, invalid building site input #{value}")

--- a/substitute-h2k.rb
+++ b/substitute-h2k.rb
@@ -2427,8 +2427,28 @@ def processFile(h2kElements)
                 locationText = "HouseFile/House/HeatingCooling/Type2/#{sysType2Name}"
                 if ( h2kElements[locationText] != nil )
                   locationText = "HouseFile/House/HeatingCooling/Type2/#{sysType2Name}/Specifications/CoolingEfficiency"
-                  h2kElements[locationText].attributes["isCop"] = "true"
-                  h2kElements[locationText].attributes["value"] = value
+                  if(h2kElements[locationText] != nil )
+                    h2kElements[locationText].attributes["isCop"] = "true"
+                    h2kElements[locationText].attributes["value"] = value
+                  else
+                    h2kElements["HouseFile/House/HeatingCooling/Type2/#{sysType2Name}/Specifications"].add_element("CoolingEfficiency")
+                    h2kElements[locationText].attributes["isCop"] = "true"
+                    h2kElements[locationText].attributes["value"] = value
+                  end
+                  if(h2kElements["HouseFile/House/HeatingCooling/Type2/#{sysType2Name}/CoolingParameters"] == nil )
+                    h2kElements["HouseFile/House/HeatingCooling/Type2/#{sysType2Name}"].add_element("CoolingParameters")
+                    h2kElements["HouseFile/House/HeatingCooling/Type2/#{sysType2Name}/CoolingParameters"].attributes["sensibleHeatRatio"] = "0.76"
+                    h2kElements["HouseFile/House/HeatingCooling/Type2/#{sysType2Name}/CoolingParameters"].attributes["openableWindowArea"] = "20"
+                    h2kElements["HouseFile/House/HeatingCooling/Type2/#{sysType2Name}/CoolingParameters"].add_element("FansAndPump")
+                    h2kElements["HouseFile/House/HeatingCooling/Type2/#{sysType2Name}/CoolingParameters/FansAndPump"].attributes["flowRate"] = "228.5837"
+                    h2kElements["HouseFile/House/HeatingCooling/Type2/#{sysType2Name}/CoolingParameters/FansAndPump"].attributes["hasEnergyEfficientMotor"] = "false"
+                    h2kElements["HouseFile/House/HeatingCooling/Type2/#{sysType2Name}/CoolingParameters/FansAndPump"].add_element("Mode")
+                    h2kElements["HouseFile/House/HeatingCooling/Type2/#{sysType2Name}/CoolingParameters/FansAndPump/Mode"].attributes["code"] = "1"
+                    h2kElements["HouseFile/House/HeatingCooling/Type2/#{sysType2Name}/CoolingParameters/FansAndPump/Mode"].add_element("English")
+                    h2kElements["HouseFile/House/HeatingCooling/Type2/#{sysType2Name}/CoolingParameters/FansAndPump/Mode"].add_element("French")
+                    h2kElements["HouseFile/House/HeatingCooling/Type2/#{sysType2Name}/CoolingParameters/FansAndPump"].add_element("Power")
+                    h2kElements["HouseFile/House/HeatingCooling/Type2/#{sysType2Name}/CoolingParameters/FansAndPump/Power"].attributes["isCalculated"] = "true"
+                  end
                 end
 
               elsif ( sysType2Name == "AirConditioning" )


### PR DESCRIPTION
- Adds in simplified capability of modelling radiant system. Under Opt-Heating-Cooling a new tag Opt-H2K-Type1IsRadiant has been added. If invoked, a radiant system is added where 90% of basement, exposed floors, floors above basement, slabs-on-grade, and crawlspace surfaces are radiant surfaces.
- Capability to input airtightness as NLR50 has been introduced for Opt-ACH
- Bug fix for modelling ASHP systems that provide both heating and cooling